### PR TITLE
Fix posterPath NoneType

### DIFF
--- a/pyoverseerr/pyoverseerr.py
+++ b/pyoverseerr/pyoverseerr.py
@@ -131,7 +131,7 @@ class Overseerr(object):
                 tv_data = self._request_connection(f"tv/{tmdb_id}").json()
                 return_array.update({
                     "last_request_title": tv_data["name"],
-                    "last_request_poster": self.get_poster_url(tv_data["posterPath"]),
+                    "last_request_poster": self.get_poster_url(tv_data["posterPath"]) if tv_data["posterPath"] is not None else '',
                     "last_request_num_seasons": self.tv_get_total_num_seasons(request),
                     "last_request_total_seasons": self.tv_get_total_num_seasons(tv_data),
                     "last_request_all_seasons": self.tv_is_all_seasons(tv_data, request),
@@ -142,7 +142,7 @@ class Overseerr(object):
                 movie_data = self._request_connection(f"movie/{tmdb_id}").json()
                 return_array.update({                  
                     "last_request_title": movie_data["title"],
-                    "last_request_poster": self.get_poster_url(movie_data["posterPath"]),
+                    "last_request_poster": self.get_poster_url(movie_data["posterPath"]) if movie_data["posterPath"] is not None else '',
                 })
             return return_array
         return None


### PR DESCRIPTION
I was having an issue where the last_movie_request entity was not being loaded, and found the following in the log:
```
2022-05-18 21:18:54 ERROR (MainThread) [homeassistant.components.sensor] overseerr: Error on device update!
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 431, in _async_add_entity
    await entity.async_device_update(warning=False)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 736, in async_device_update
    await task
  File "/usr/local/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/overseerr/sensor.py", line 71, in update
    self._last_request = self._overseerr.last_movie_request
  File "/usr/local/lib/python3.9/site-packages/pyoverseerr.py", line 241, in last_movie_request
    return self.create_request_object(request)
  File "/usr/local/lib/python3.9/site-packages/pyoverseerr.py", line 145, in create_request_object
    "last_request_poster": self.get_poster_url(movie_data["posterPath"]),
  File "/usr/local/lib/python3.9/site-packages/pyoverseerr.py", line 103, in get_poster_url
    return ("https://image.tmdb.org/t/p/w600_and_h900_bestv2" + path)
TypeError: can only concatenate str (not "NoneType") to str
```

*edit* added log info