### PR TITLE
Simplify Overseerr Initialization

### DIFF
--- a/pyoverseerr/pyoverseerr.py
+++ b/pyoverseerr/pyoverseerr.py
@@ -17,14 +17,8 @@ def request(f):
 class Overseerr(object):
     """A class for handling connections with an Overseerr instance."""
 
-    def __init__(self, ssl, username, host, port, urlbase="", api_key=None, password=None):
-
-        self._base_url = _BASE_URL.format(
-            ssl="s" if ssl else "", host=host, port=port, urlbase=urlbase)
-        self._app_base = "http{ssl}://{host}:{port}".format(
-            ssl="s" if ssl else "", host=host, port=port)
-#        self._app_base = "http{ssl}://{host}:{port}/{urlbase}".format(ssl="s" if ssl else "", host=host, port=port, urlbase=urlbase)
-
+    def __init__(self, url, api_key=None):
+        self._base_url = _BASE_URL.format(url=url)
         self._api_key = api_key
         self._auth = None
         self._applicationUrl = None

--- a/pyoverseerr/pyoverseerr.py
+++ b/pyoverseerr/pyoverseerr.py
@@ -4,7 +4,6 @@ import json
 import logging
 
 _LOGGER = logging.getLogger(__name__)
-_BASE_URL = "http{ssl}://{host}:{port}/{urlbase}api/v1/"
 _TAKE_COUNT = 1000
 
 
@@ -18,7 +17,7 @@ class Overseerr(object):
     """A class for handling connections with an Overseerr instance."""
 
     def __init__(self, url, api_key=None):
-        self._base_url = _BASE_URL.format(url=url)
+        self._base_url = "{url}/api/v1/".format(url=url)
         self._api_key = api_key
         self._auth = None
         self._applicationUrl = None


### PR DESCRIPTION
This PR introduces some enhancements to the `pyoverseerr` module. The primary goal is to make the codebase more Pythonic by simplifying object initialization.

Most users setup their overseerrs behind reverse proxies so the interface wasn't supporting those use cases before, and this new approach supports any setup.

## Changes:

* Reduced the number of parameters in the `__init__` method of the Overseerr class.
* The `ssl`, `username`, `host`, `port`, and `urlbase` parameters have been removed.
* Introduced a single `url `parameter to take the full URL, which makes the initialization straightforward and less error-prone.
* Removed a commented out line for cleanliness.
* Removed the `_BASE_URL `constant as it was only used once.
* Replaced the use of `_BASE_URL` in the `__init__` method with a direct string format.